### PR TITLE
[KAIZEN-0] Sett cpu limit til 3

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -18,7 +18,7 @@ prometheus:
   path: tiltakinfo/internal/metrics
 resources:
   limits:
-    cpu: 500m
+    cpu: 3
     memory: 1024Mi
   requests:
     cpu: 200m


### PR DESCRIPTION
Prosjektet er avhengig av pus-decorator som er en java-app. Java-applikasjoner har lang oppstartstid noe som fører til at kubernetes kan time ut ved deploy. Løsningen er å øke taket på cpu-ressurser til applikasjon slik at oppstartstiden blir kortere.